### PR TITLE
Added testing for 0.1.x branch, Switched to Python 3.7+ for main

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -1,15 +1,15 @@
-name: Tests
+name: 0.1.x-Tests
 on:
   push:
     branches:
-    - master
+    - 0.1.x
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [2.7, 3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +20,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install virtualenv==15.2
+        pip install tox==3.12.1 tox-gh-actions
         pip install poetry==1.1.4
     - name: Test with tox
       run: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/rajivsarvepalli/mock-alchemy"
 authors = ["Rajiv Sarvepalli <rajiv@sarvepalli.net>", "Miroslav Shubernetskiy <mail@miki725.com>", "Serkan Hoscai <serkan@hosca.com"]
 readme = "README.rst"
 keywords = ["sqlalchemy mock testing", "sqlalchemy mock", "mock sqlalchemy"]
-documentation = "https://mockalchemy.readthedocs.io"
+documentation = "https://mock-alchemy.readthedocs.io"
 classifiers=[
     "Intended Audience :: Developers",
     "Natural Language :: English",


### PR DESCRIPTION
Added workflow for the 0.1.x branch to test on Python 2.7, Python 3.6, and Python 3.7, but switched testing on the main branch to be on Python 3.7, Python 3.8, and Python 3.8. This improvement will enable the transition over to Python 3.7 for future releases while keeping Python 2.7 support in the 0.1.x releases.

Fixes #1 