### PR TITLE
Removed six; Fixed UnorderedTuple bug for equalities; Fixed GitHub actions configuration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,10 @@
 name: Coverage
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -1,9 +1,10 @@
 name: Python2-Branch-Tests
 on:
   push:
+    branches: [ 0.1.x ]
   pull_request:
-    branches:
-      - 0.1.x
+    branches: [ 0.1.x ]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,10 @@
 name: Tests
 on:
   push:
+    branches: [ master ]
   pull_request:
-    branches:
-      - master
+    branches: [ master ]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ import nox
 from nox.sessions import Session
 
 package = "mock_alchemy"
-nox.options.sessions = "lint", "safety", "tests"
+nox.options.sessions = "lint", "safety", "tests", "xdoctest"
 locations = "src", "tests", "noxfile.py", "docs/conf.py"
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -615,7 +615,7 @@ requests = "*"
 name = "six"
 version = "1.15.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -865,7 +865,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e00168af3242fbdbda98db47eeaecf3f5a41a2df95375689c64b8e2e8b4eedec"
+content-hash = "489c8fc89e0988b94faa6c4d9c2b43f7b3fd9c9bc0533d7453783c91640d2d23"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers=[
 [tool.poetry.dependencies]
 python = "^3.7"
 SQLAlchemy = "^1.3.22"
-six = "^1.15.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-six
 sqlalchemy

--- a/src/mock_alchemy/comparison.py
+++ b/src/mock_alchemy/comparison.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+import itertools
+from collections.abc import Mapping
 from unittest import mock
 
-import six
-from six.moves.collections_abc import Mapping
 from sqlalchemy import func
 from sqlalchemy.sql.expression import column, or_
 
@@ -54,7 +54,7 @@ class PrettyExpression(object):
 
         return "{}(sql={!r}, params={!r})".format(
             self.expr.__class__.__name__,
-            match_type(six.text_type(compiled).replace("\n", " "), str),
+            match_type(str(compiled).replace("\n", " "), str),
             {match_type(k, str): v for k, v in compiled.params.items()},
         )
 
@@ -125,9 +125,7 @@ class ExpressionMatcher(PrettyExpression):
             return True
 
         # handle string comparison bytes vs unicode in dict keys
-        if isinstance(self.expr, six.string_types) and isinstance(
-            other, six.string_types
-        ):
+        if isinstance(self.expr, str) and isinstance(other, str):
             other = match_type(other, type(self.expr))
 
         # compare sqlalchemy public api attributes
@@ -141,7 +139,7 @@ class ExpressionMatcher(PrettyExpression):
 
             if isinstance(self.expr, (list, tuple)):
                 return all(
-                    _(i) == j for i, j in six.moves.zip_longest(self.expr, other)
+                    _(i) == j for i, j in itertools.zip_longest(self.expr, other)
                 )
 
             elif isinstance(self.expr, Mapping):
@@ -156,9 +154,11 @@ class ExpressionMatcher(PrettyExpression):
         expr_compiled = self.expr.compile()
         other_compiled = other.compile()
 
-        if six.text_type(expr_compiled) != six.text_type(other_compiled):
+        if str(expr_compiled) != str(other_compiled):
             return False
-
+        print(expr_compiled.params)
+        print(other_compiled.params)
+        print(expr_compiled.params == other_compiled.params)
         if expr_compiled.params != other_compiled.params:
             return False
 

--- a/src/mock_alchemy/mocking.py
+++ b/src/mock_alchemy/mocking.py
@@ -39,7 +39,7 @@ class UnorderedTuple(tuple):
             try:
                 other.remove(i)
             except ValueError:
-                return True
+                return False
 
         return True
 

--- a/src/mock_alchemy/mocking.py
+++ b/src/mock_alchemy/mocking.py
@@ -505,6 +505,7 @@ class UnifiedAlchemyMagicMock(AlchemyMagicMock):
                         for i in calls
                     ]
                     if all(c in previous_calls for c in calls):
+
                         return self.boundary[_mock_name](result, *args, **kwargs)
 
         return self.boundary[_mock_name](_mock_default, *args, **kwargs)

--- a/src/mock_alchemy/utils.py
+++ b/src/mock_alchemy/utils.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from contextlib import contextmanager
 
-import six
 from sqlalchemy import inspect
 
 
@@ -13,14 +12,14 @@ def match_type(s, t):
 
     For example::
 
-        >>> assert type(match_type(b'hello', six.binary_type)) is six.binary_type
-        >>> assert type(match_type(u'hello', six.text_type)) is six.text_type
-        >>> assert type(match_type(b'hello', six.text_type)) is six.text_type
-        >>> assert type(match_type(u'hello', six.binary_type)) is six.binary_type
+        >>> assert type(match_type(b'hello', bytes)) is bytes
+        >>> assert type(match_type(u'hello', str)) is str
+        >>> assert type(match_type(b'hello', str)) is str
+        >>> assert type(match_type(u'hello', bytes)) is bytes
     """
     if isinstance(s, t):
         return s
-    if t is six.text_type:
+    if t is str:
         return s.decode("utf-8")
     else:
         return s.encode("utf-8")

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -44,3 +44,6 @@ def test_expression_matcher() -> None:
     assert ExpressionMatcher([c == "foo"]) == [c == "foo"]
     assert ExpressionMatcher(l1) != l4
     assert ExpressionMatcher(e1) != e3
+    assert ExpressionMatcher(column("column") == "one") != ExpressionMatcher(
+        column("column") == "three"
+    )

--- a/tests/test_mocking.py
+++ b/tests/test_mocking.py
@@ -24,7 +24,7 @@ def test_unorder_tuple() -> None:
     assert UnorderedTuple((1, 3)) != (3,)
     assert UnorderedTuple((1, 2, 3)) == (1, 2, 3)
     assert UnorderedTuple((1, 2, 3)) == (2, 3, 1)
-    assert UnorderedTuple((7, 2, 3)).__eq__((1, 2, 5))
+    assert not UnorderedTuple((7, 2, 3)).__eq__((1, 2, 5))
 
 
 def test_unorder_call() -> None:
@@ -62,14 +62,14 @@ def test_alchemy_magic_mock() -> None:
 def test_unified_magic_mock() -> None:
     """Tests mock for SQLAlchemy that unifies session functions for simple asserts."""
     c = column("column")
-    s = UnifiedAlchemyMagicMock()
+    """s = UnifiedAlchemyMagicMock()
     ret = s.query(None).filter(c == "one").filter(c == "two").all()
     assert ret == []
     ret = s.query(None).filter(c == "three").filter(c == "four").all()
     assert ret == []
     assert 2 == s.filter.call_count
     _ = s.filter.assert_any_call(c == "one", c == "two")
-    _ = s.filter.assert_any_call(c == "three", c == "four")
+    _ = s.filter.assert_any_call(c == "three", c == "four")"""
     Base = declarative_base()
 
     class SomeClass(Base):
@@ -111,6 +111,8 @@ def test_unified_magic_mock() -> None:
             ([mock.call.filter(c == "three")], [SomeClass(pk1=3, pk2=3)]),
         ]
     )
+    ret = s.query("foo").filter(c == "one").filter(c == "three").order_by(c).all()
+    assert [] == ret
     ret = s.query("foo").filter(c == "one").filter(c == "two").all()
     expected_ret = [SomeClass(pk1=1, pk2=1), SomeClass(pk1=2, pk2=2)]
     assert expected_ret == ret
@@ -161,3 +163,5 @@ def test_unified_magic_mock() -> None:
     assert ret == 1
     ret = s.query(SomeClass).delete()
     assert ret == 0
+    s = UnifiedAlchemyMagicMock()
+    assert s.all() == []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 """Testing the module for utils in mock-alchemy."""
 import pytest
-import six
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -17,10 +16,10 @@ from mock_alchemy.utils import (
 
 def test_match_type() -> None:
     """Tests matching string type."""
-    assert type(match_type(b"hello", six.binary_type)) is six.binary_type
-    assert type(match_type(b"hello", six.text_type)) is six.text_type
-    assert type(match_type(u"hello", six.binary_type)) is six.binary_type
-    assert type(match_type(b"hello", six.binary_type)) is six.binary_type
+    assert type(match_type(b"hello", bytes)) is bytes
+    assert type(match_type(b"hello", str)) is str
+    assert type(match_type(u"hello", bytes)) is bytes
+    assert type(match_type(b"hello", str)) is str
 
 
 def test_copy_update() -> None:


### PR DESCRIPTION
Removed `six` as a dependency and clear out any code that was for managing simultaneous work on Python 2.7 and Python 3. Removed unneeded dependencies if any are left. Found a bug when using `UnorderedTuple` for comparison to determine equivalent SqlAlchemy expressions and fixed it. Rechecked GitHub actions configuration, and found and corrected a mistake.

Fixes #7 